### PR TITLE
GUNDI-4159: Get animals info and attach it to subject

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -34,7 +34,7 @@ def transform(farm, animals_info, observation):
        f"{observation.official_tag} ({observation.device_name})"
     )
 
-    subject_type = f"rumi-{animal_info.get('type')}" if animal_info else "tracking-device"
+    subject_type = f"rumi-{animal_info.get('type')}" if animal_info else "unassigned"
 
     additional_info = {
         key: value for key, value in (animal_info or {}).items() if value
@@ -43,8 +43,8 @@ def transform(farm, animals_info, observation):
     return {
         "source_name": source_name,
         "source": observation.official_tag,
-        "type": subject_type,
-        "subject_type": "unassigned",
+        "type": "tracking-device",
+        "subject_type": subject_type,
         "recorded_at": observation.time,
         "location": {
             "lat": observation.location[0],

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -20,12 +20,13 @@ class IntegrationStateManager:
         value = json.loads(json_value) if json_value else {}
         return value
 
-    async def set_state(self, integration_id: str, action_id: str, state: dict, source_id: str = "no-source"):
+    async def set_state(self, integration_id: str, action_id: str, state: dict, source_id: str = "no-source", expire: int = None):
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
                 await self.db_client.set(
                     f"integration_state.{integration_id}.{action_id}.{source_id}",
-                    json.dumps(state, default=str)
+                    json.dumps(state, default=str),
+                    ex=expire
                 )
 
     async def delete_state(self, integration_id: str, action_id: str, source_id: str = "no-source"):

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -22,7 +22,8 @@ async def test_set_integration_state(mocker, mock_redis, integration_v2):
 
     mock_redis.Redis.return_value.set.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.no-source",
-        '{"last_execution": "' + execution_timestamp + '"}'
+        '{"last_execution": "' + execution_timestamp + '"}',
+        ex=None
     )
 
 
@@ -59,12 +60,13 @@ async def test_delete_integration_state(mocker, mock_redis, integration_v2):
         integration_id=integration_id,
         action_id="pull_observations",
         # No source set
-        state=state
+        state=state,
     )
 
     mock_redis.Redis.return_value.set.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.no-source",
-        '{"last_execution": "' + execution_timestamp + '"}'
+        '{"last_execution": "' + execution_timestamp + '"}',
+        ex=None
     )
 
     # then delete the state
@@ -96,7 +98,8 @@ async def test_set_source_state(mocker, mock_redis, integration_v2, mock_integra
 
     mock_redis.Redis.return_value.set.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}",
-        json.dumps(mock_integration_state, default=str)
+        json.dumps(mock_integration_state, default=str),
+        ex=None
     )
 
 
@@ -136,7 +139,8 @@ async def test_delete_state_source_state(mocker, mock_redis, integration_v2, moc
 
     mock_redis.Redis.return_value.set.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}",
-        json.dumps(mock_integration_state, default=str)
+        json.dumps(mock_integration_state, default=str),
+        ex=None
     )
 
     # delete state


### PR DESCRIPTION
### Relevant Link:

https://allenai.atlassian.net/browse/GUNDI-4159

---

This pull request introduces a new function to fetch detailed information about animals on a farm and integrates this data into the existing observation transformation process.

The changes include adding a new function to retrieve animal information, updating the transformation logic to include animal details, and modifying state management to cache the retrieved information.

### New Functionality:

* [`app/actions/client.py`](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013R117-R170): Added `get_animals_info` function to fetch information about bulls, cows, and calves from the farm's API and handle potential HTTP errors with retries.

### Updates to Existing Functionality:

* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L21-R87): Updated the `transform` function to include animal information in the observation transformation. This includes mapping `rumi_id` to animal details and updating the `source_name` and `subject_type` accordingly.
* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L119-R169): Modified `action_fetch_farm_observations` to call `get_animals_info` and pass the retrieved data to the `transform` function.

### State Management Enhancements:

* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L21-R87): Added logic to cache the animal information using `state_manager` and retrieve it if available, reducing the number of API calls.
* [`app/services/state.py`](diffhunk://#diff-82e2152ea754688cadb39a5a97ad11e8543391c11258cc974dc5d4b4d4833fe4L23-R29): Updated `set_state` to accept an `expire` parameter, allowing cached data to have a specified expiration time.

### How it looks in ER?

![image](https://github.com/user-attachments/assets/0d36931f-efc9-4994-9076-72900606df90)

![image](https://github.com/user-attachments/assets/544bf0a9-fe74-4197-aff3-e694e79b6728)
