### PR TITLE
GUNDI-4813: Release 20251016 hotfix

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -33,7 +33,7 @@ class PullObservationsConfig(PullActionConfiguration):
 
 class PullFarmObservationsConfig(PullActionConfiguration):
     start: datetime
-    stop: datetime = datetime.now(timezone.utc)
+    stop: datetime = pydantic.Field(..., default_factory=lambda: datetime.now(timezone.utc))
     locations: str = "all"
     farm_id: str
     farm_name: str

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -33,7 +33,7 @@ class PullObservationsConfig(PullActionConfiguration):
 
 class PullFarmObservationsConfig(PullActionConfiguration):
     start: datetime
-    stop: datetime = pydantic.Field(..., default_factory=lambda: datetime.now(timezone.utc))
+    stop: datetime = pydantic.Field(default_factory=lambda: datetime.now(timezone.utc))
     locations: str = "all"
     farm_id: str
     farm_name: str


### PR DESCRIPTION
This pull request makes a minor improvement to the default value assignment for the `stop` field in the `PullFarmObservationsConfig` class. The change ensures that the default value for `stop` is set at instantiation time rather than at import time, which is a best practice when using mutable or dynamic defaults like `datetime.now()`.

- Updated the `stop` field in `PullFarmObservationsConfig` to use `pydantic.Field` with a `default_factory` for correct default timestamp behavior.